### PR TITLE
auto escape . in encoding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vlbuildr
 Title: Build vega-lite specs in R
-Version: 0.0.1.9003
+Version: 0.0.1.9004
 Authors@R: person("Aicia", "Schep", email = "aschep@gmail.com", role = c("aut", "cre"))
 Description: Build vegalite specs in R. Inspired by vegalite package as well as 
   vega-lite-api and altair. Dependent on vegawidget for actually rendering specs!

--- a/R/encoding.R
+++ b/R/encoding.R
@@ -37,6 +37,11 @@ ENCODE_MAPPING <- list(
       }
     }
     
+    # Escape "." in feild
+    if (hasName(enc,"field")){
+      enc$field <- gsub("\\.","\\\\.", enc$field)
+    }
+    
     if (!hasName(spec,"encoding")) spec$encoding <- list()
     validate_sub_schema(enc, ref)
     spec[["encoding"]][[encoding]] <- enc

--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -43,6 +43,15 @@ test_that("can use vl_encode with facet", {
   expect_equivalent(chart$facet, list(field = "x", type = "quantitative"))
 })
 
-
+test_that("encode functions escapes field names with .", {
+  
+  
+  chart <- vl_chart() %>% 
+    vl_encode_x(field = "abba.daba.doo", type = "quantitative" )
+  
+  expect_equivalent(chart$encoding$x$field, "abba\\.daba\\.doo")
+  
+  
+})
 
 


### PR DESCRIPTION
Addresses #27 

Note: seems like one of the "\" ends up in the axis title this way.. but that seems like a vega-lite issue.